### PR TITLE
allow creation of paragraph in body above/below table

### DIFF
--- a/src/gapcursor.js
+++ b/src/gapcursor.js
@@ -24,7 +24,7 @@ export class GapCursor extends Selection {
     // Tries precise position first, then positions before it (by
     // entering nodes starting directly before), then positions after.
     let textBlockWrapper = content.content.content.every(node => node.isInline) ?
-      Object.values($pos.doc.type.schema.nodes).find(node => node.spec.defaultTextBlock) :
+      Object.values($pos.doc.type.schema.nodes).find(node => node.isTextblock) :
       false
 
     for (let dir = -1, pos = $pos.pos;;) {


### PR DESCRIPTION
This allows using `allowGapCursor = false` on nodes higher up to prevent the gap cursor to be placed in them. Also, when inserting inline nodes into blocks that are not Textblock nodes, it doesn't try to directly insert the nodes, but wraps them inside a textblocknode ~type defined with `defaultTextBlock = true` in the schema~.

This should not be merged directly, as I was missing a lot of knowledge about other situations in which gapcursor is to be used, so I don't know if it is breaking anything for others. Also, it seems like there already is a way to determine which textblock node is the default one, or how content should be wrapped that is being used in other places. At any rate, I hope this serves to show what kinds of additions we would need for our particular usecase.