### PR TITLE
make gapcursor stop at defining nodes

### DIFF
--- a/src/gapcursor.js
+++ b/src/gapcursor.js
@@ -108,7 +108,7 @@ function closedAfter($pos) {
     let index = $pos.indexAfter(d), parent = $pos.node(d)
     if (index == parent.childCount) continue
     for (let after = parent.child(index);; after = after.firstChild) {
-      if (after.type.spec.defining) return true
+     // if (after.type.spec.defining) return true
       if (after.isTextblock) return false
       if (after.childCount == 0 || after.isAtom || after.type.spec.isolating) return true
     }

--- a/src/gapcursor.js
+++ b/src/gapcursor.js
@@ -94,6 +94,7 @@ function closedBefore($pos) {
     if (index == 0) continue
     // See if the node before (or its first ancestor) is closed
     for (let before = $pos.node(d).child(index - 1);; before = before.lastChild) {
+      if (before.type.spec.defining) return true
       if (before.isTextblock) return false
       if (before.childCount == 0 || before.isAtom || before.type.spec.isolating) return true
     }
@@ -107,6 +108,7 @@ function closedAfter($pos) {
     let index = $pos.indexAfter(d), parent = $pos.node(d)
     if (index == parent.childCount) continue
     for (let after = parent.child(index);; after = after.firstChild) {
+      if (after.type.spec.defining) return true
       if (after.isTextblock) return false
       if (after.childCount == 0 || after.isAtom || after.type.spec.isolating) return true
     }

--- a/src/gapcursor.js
+++ b/src/gapcursor.js
@@ -108,7 +108,7 @@ function closedAfter($pos) {
     let index = $pos.indexAfter(d), parent = $pos.node(d)
     if (index == parent.childCount) continue
     for (let after = parent.child(index);; after = after.firstChild) {
-     // if (after.type.spec.defining) return true
+      if (after.type.spec.defining) return true
       if (after.isTextblock) return false
       if (after.childCount == 0 || after.isAtom || after.type.spec.isolating) return true
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {keydownHandler} from "prosemirror-keymap"
-import {TextSelection, Plugin} from "prosemirror-state"
+import {TextSelection, NodeSelection, Plugin} from "prosemirror-state"
 import {Decoration, DecorationSet} from "prosemirror-view"
 
 import {GapCursor} from "./gapcursor"
@@ -39,8 +39,16 @@ const handleKeyDown = keydownHandler({
 function arrow(axis, dir) {
   let dirStr = axis == "vert" ? (dir > 0 ? "down" : "up") : (dir > 0 ? "right" : "left")
   return function(state, dispatch, view) {
-    let sel = state.selection
-    let $start = dir > 0 ? sel.$to : sel.$from, mustMove = sel.empty
+    let sel = state.selection, $start, mustMove
+    if (sel instanceof NodeSelection) {
+      // In case of node selections, look for a valid position starting with the end/start
+      // of the node itself : [<node>] ==right==> <node>|
+      $start = dir > 0 ? sel.$from : sel.$to
+      mustMove = false
+    } else {
+      $start = dir > 0 ? sel.$to : sel.$from
+      mustMove = sel.empty
+    }
     if (sel instanceof TextSelection) {
       if (!view.endOfTextblock(dirStr)) return false
       mustMove = false


### PR DESCRIPTION
This works for me (I think), but I must admit I don't understand the idea behind some parts of it. 
This does two things: 

A) Take the defining attribute of nodes as a definite boundary so that the gapcursor can be placed on either side if appropriate.


B) When the old state had a node selection, it seems like we need to look for a valid position starting from the end of the node in the given direction, and given that we start by increasing/decreasing the position by 1 before checking for validity, we need to give it the opposing edge as a starting point.

So for example, current selection (a node selection) is:

    <p>blablbla[<image>]</p>

The user uses the right arrow key. The first position we need to check for validity is here:

    <p>blablbla<image>|</p>

But because the checker automatically changes the position by one, we need to use this as the starting check position:

    <p>blablbla|<image></p>


Maybe this makes sense. Maybe I didn't get central parts about how this is to function.