### PR TITLE
Fix gapcursor style path

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,7 @@ that don't allow regular selection (such as positions that have a leaf
 block node, table, or the end of the document both before and after
 them).
 
-You'll probably want to load `style/block-cursor.css`, which contains
+You'll probably want to load `style/gapcursor.css`, which contains
 basic styling for the simulated cursor (as a short, blinking
 horizontal stripe).
 


### PR DESCRIPTION
This corrects the path to the CSS file ([`style/gapcursor.css`](https://github.com/ProseMirror/prosemirror-gapcursor/blob/master/style/gapcursor.css)) in the documentation.