### PR TITLE
Add license metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "prosemirror-gapcursor",
   "version": "1.0.2",
   "description": "ProseMirror plugin for cursors at normally impossible-to-reach positions",
+  "license": "MIT",
   "main": "dist/index.js",
   "style": "style/gapcursor.css",
   "dependencies": {


### PR DESCRIPTION
This tiny PR adds a `license` string to `package.json` to match the MIT terms in `LICENSE`.

Adding license metadata to `package.json` allows users to audit open source licenses automatically, without reviewing every dependency in `node_modules`.  Many tools also use `package.json` license metadata to compile notice files, to make sure each dependency author gets the credit their license requires.

You can find more information on `license` properties in `package.json` files [on the doc page for `package.json`](https://docs.npmjs.com/files/package.json#license).