### PR TITLE
Don't create gap cursor when the view is not editable.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ function arrow(axis, dir) {
 }
 
 function handleClick(view, pos, event) {
+  if (view.someProp("editable", editable => editable(view.state) === false)) return false
   let $pos = view.state.doc.resolve(pos)
   if (!GapCursor.valid($pos)) return false
   let {inside} = view.posAtCoords({left: event.clientX, top: event.clientY})


### PR DESCRIPTION
The gap cursor should only be created on click if the view is actually editable, matching the behavior the the regular/native cursor.