### PR TITLE
fix: gap cursor weird positioning inside inline nodes

### DIFF
--- a/src/gapcursor.ts
+++ b/src/gapcursor.ts
@@ -37,7 +37,7 @@ export class GapCursor extends Selection {
   /// @internal
   static valid($pos: ResolvedPos) {
     let parent = $pos.parent
-    if (parent.isTextblock || !closedBefore($pos) || !closedAfter($pos)) return false
+    if (parent.isTextblock || parent.inlineContent || !closedBefore($pos) || !closedAfter($pos)) return false
     let override = parent.type.spec.allowGapCursor
     if (override != null) return override
     let deflt = parent.contentMatchAt($pos.index()).defaultType


### PR DESCRIPTION
Currently when a the cursor moves inside an inline node, a gap cursor might be created anywhere in the text, this is a weird interaction and this commit tries to solve this issue.

However it would be nice being able to have inline gap cursors as well, but this is probably up for another discussion.